### PR TITLE
Use proper sidekiq API for queue name

### DIFF
--- a/lib/sidekiq/instrument/mixin.rb
+++ b/lib/sidekiq/instrument/mixin.rb
@@ -4,7 +4,7 @@ module Sidekiq::Instrument
       if worker.respond_to?(:statsd_metric_name)
         worker.send(:statsd_metric_name, event)
       else
-        queue = worker.sidekiq_options_hash['queue']
+        queue = worker.class.get_sidekiq_options['queue']
         name = worker.class.name.gsub('::', '_')
 
         "shared.sidekiq.#{queue}.#{name}.#{event}"


### PR DESCRIPTION
`sideqik_options_hash` may not always be initialized, if you don't specify sidekiq options explicitely. 

Using the `get_sidekiq_options` will return default values (such as `default` queue name) unless you override them with `sidekiq_options`.