### PR TITLE
add queue latency to Sidekiq::Instrument::Worker

### DIFF
--- a/lib/sidekiq/instrument/worker.rb
+++ b/lib/sidekiq/instrument/worker.rb
@@ -30,6 +30,10 @@ module Sidekiq::Instrument
       info.queues.each do |name, size|
         StatsD.gauge "shared.sidekiq.#{name}.size", size
       end
+
+      Sidekiq::Queue.all.each do |queue|
+        StatsD.gauge "shared.sidekiq.#{queue.name}.latency", queue.latency
+      end
     end
   end
 end

--- a/spec/sidekiq-instrument/worker_spec.rb
+++ b/spec/sidekiq-instrument/worker_spec.rb
@@ -30,6 +30,10 @@ RSpec.describe Sidekiq::Instrument::Worker do
       it 'gauges the size of the queues' do
         expect { worker.perform }.to trigger_statsd_gauge('shared.sidekiq.default.size')
       end
+
+      it 'gauges the latency of the queues' do
+        expect { worker.perform }.to trigger_statsd_gauge('shared.sidekiq.default.latency')
+      end
     end
   end
 end


### PR DESCRIPTION
🌵 

Updating `Sidekiq::Instrument::Worker` to gauge queue latency.