### PR TITLE
loosen statsd-instrument dependency version

### DIFF
--- a/sidekiq-instrument.gemspec
+++ b/sidekiq-instrument.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'sidekiq', '>= 4.2', '< 7'
-  spec.add_dependency 'statsd-instrument', '~> 2.0', '>= 2.0.4'
+  spec.add_dependency 'statsd-instrument', '>= 2.0.4'
 
   spec.add_development_dependency 'bundler', '~> 2.0', '>= 2.0.2'
   spec.add_development_dependency 'rake', '~> 12.0'


### PR DESCRIPTION
Hello,

version 3 of `statsd-instrument` gem was released over 2 years ago https://rubygems.org/gems/statsd-instrument/versions. I wanted to check if there are any known incompatibilities that should be resolved before dropping the dependency on version 2. 

As far as I've read the migration docs https://github.com/Shopify/statsd-instrument/blob/master/CHANGELOG.md#version-300 I believe the library should work. I also tested it on my own and I see no regression (one thing I should mention though is the verbose logging in the test output).