### PR TITLE
Drop workflow_dispatch Actions trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
The trigger did not work as intended, and having the CI tests be manually triggerable via this trigger was not important to the sidekiq-instrument GitHub Actions integration.