### PR TITLE
Add explicit dogstatsd metric flushing

### DIFF
--- a/lib/sidekiq/instrument/middleware/client.rb
+++ b/lib/sidekiq/instrument/middleware/client.rb
@@ -10,8 +10,9 @@ module Sidekiq::Instrument
       class_instance = klass.new
       Statter.statsd.increment(metric_name(class_instance, 'enqueue'))
       Statter.dogstatsd&.increment('sidekiq.enqueue', worker_dog_options(class_instance))
-
-      yield
+      result = yield
+      Statter.dogstatsd&.flush(sync: true)
+      result
     end
   end
 end

--- a/lib/sidekiq/instrument/middleware/server.rb
+++ b/lib/sidekiq/instrument/middleware/server.rb
@@ -17,6 +17,8 @@ module Sidekiq::Instrument
       Statter.statsd.increment(metric_name(worker, 'error'))
       Statter.dogstatsd&.increment('sidekiq.error', worker_dog_options(worker))
       raise e
+    ensure
+      Statter.dogstatsd&.flush(sync: true)
     end
   end
 end

--- a/lib/sidekiq/instrument/version.rb
+++ b/lib/sidekiq/instrument/version.rb
@@ -1,5 +1,5 @@
 module Sidekiq
   module Instrument
-    VERSION = "0.5.0"
+    VERSION = "0.5.1"
   end
 end

--- a/lib/sidekiq/instrument/worker.rb
+++ b/lib/sidekiq/instrument/worker.rb
@@ -38,6 +38,8 @@ module Sidekiq::Instrument
         Statter.statsd.gauge("shared.sidekiq.#{queue.name}.latency", queue.latency)
         Statter.dogstatsd&.gauge('sidekiq.queue.latency', queue.latency, tags: ["queue:#{queue.name}"])
       end
+
+      Statter.dogstatsd&.flush(sync: true)
     end
   end
 end

--- a/sidekiq-instrument.gemspec
+++ b/sidekiq-instrument.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'sidekiq', '>= 4.2', '< 7'
   spec.add_dependency 'statsd-instrument', '>= 2.0.4'
-  spec.add_dependency 'dogstatsd-ruby', '~> 5.5.0'
+  spec.add_dependency 'dogstatsd-ruby', '~> 5.5'
   spec.add_dependency 'activesupport', '>= 5.1', '< 7'
 
   spec.add_development_dependency 'bundler', '~> 2.0', '>= 2.0.2'


### PR DESCRIPTION
Also reduced the specificity of the dogstatsd-ruby gem version requirement, pinning to major version > 5.5 rather than minor version > 5.5.0.