### PR TITLE
Fix an issue with global StatsD in Statter

### DIFF
--- a/lib/sidekiq/instrument.rb
+++ b/lib/sidekiq/instrument.rb
@@ -1,4 +1,5 @@
-require 'active_support/core_ext/class/attribute'
+require "active_support/core_ext/class/attribute"
+require "statsd/instrument"
 
 require "sidekiq/instrument/statter"
 require "sidekiq/instrument/version"

--- a/lib/sidekiq/instrument/version.rb
+++ b/lib/sidekiq/instrument/version.rb
@@ -1,5 +1,5 @@
 module Sidekiq
   module Instrument
-    VERSION = "0.5.1"
+    VERSION = "0.5.2"
   end
 end


### PR DESCRIPTION
When lazy-loading the gem externally via "require: false" in the Gemfile, the StatsD global was humming along just fine, but for all projects not lazy-loading the gem, sidekiq-instrument was failing, citing an unitialized constant StatsD.  This fix addresses the issue by having sidekiq-instrument provide the global itself rather than relying upon external code to provide StatsD.