### PR TITLE
Fix dogstatsd formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ For each job, the following metrics and tags will be reported:
    job fails.
 
 For each queue, the following metrics and tags will be reported:
-1. **sidekiq.queue_size (tags: {queue: _queue_})**: gauge of how many jobs are in the queue
-1. **sidekiq.queue_latency (tags: {queue: _queue_})**: gauge of how long the oldest job has been in the queue
+1. **sidekiq.queue.size (tags: {queue: _queue_})**: gauge of how many jobs are in the queue
+1. **sidekiq.queue.latency (tags: {queue: _queue_})**: gauge of how long the oldest job has been in the queue
 
 ## Worker
 There is a worker, `Sidekiq::Instrument::Worker`, that submits gauges

--- a/lib/sidekiq/instrument/mixin.rb
+++ b/lib/sidekiq/instrument/mixin.rb
@@ -9,7 +9,7 @@ module Sidekiq::Instrument
     end
 
     def worker_dog_options(worker)
-      { tags: ["queue:#{queue_name(worker)}", "worker:#{class_name(worker)}"] }
+      { tags: ["queue:#{queue_name(worker)}", "worker:#{underscore(class_name(worker))}"] }
     end
 
     private
@@ -20,6 +20,14 @@ module Sidekiq::Instrument
 
     def class_name(worker)
       worker.class.name.gsub('::', '_')
+    end
+
+    def underscore(string)
+      string.gsub(/::/, '/').
+        gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2').
+        gsub(/([a-z\d])([A-Z])/,'\1_\2').
+        tr("-", "_").
+        downcase
     end
   end
 end

--- a/lib/sidekiq/instrument/version.rb
+++ b/lib/sidekiq/instrument/version.rb
@@ -1,5 +1,5 @@
 module Sidekiq
   module Instrument
-    VERSION = "0.5.2"
+    VERSION = "0.5.3"
   end
 end

--- a/spec/sidekiq-instrument/client_middleware_spec.rb
+++ b/spec/sidekiq-instrument/client_middleware_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Sidekiq::Instrument::ClientMiddleware do
       end
 
       it 'increments the DogStatsD enqueue counter' do
-        expect(Sidekiq::Instrument::Statter.dogstatsd).to receive(:increment).with('sidekiq.enqueue', { tags: ['queue:default', 'worker:MyWorker'] }).once
+        expect(Sidekiq::Instrument::Statter.dogstatsd).to receive(:increment).with('sidekiq.enqueue', { tags: ['queue:default', 'worker:my_worker'] }).once
         MyWorker.perform_async
       end
     end

--- a/spec/sidekiq-instrument/server_middleware_spec.rb
+++ b/spec/sidekiq-instrument/server_middleware_spec.rb
@@ -2,7 +2,7 @@ require 'sidekiq/instrument/middleware/server'
 
 RSpec.describe Sidekiq::Instrument::ServerMiddleware do
   describe '#call' do
-    let(:expected_dog_options) { { tags: ['queue:default', 'worker:MyWorker'] } }
+    let(:expected_dog_options) { { tags: ['queue:default', 'worker:my_worker'] } }
 
     before(:all) do
       Sidekiq::Testing.server_middleware do |chain|


### PR DESCRIPTION
This PR corrects the poor formatting of DogStatsD tags, specifically the worker tag. Previously, due to the down casing that Datadog does on metrics, multi-word worker names became one large, lowercased string. For example, a worker that could be named `MySidekiqWorker` would display in Datadog as `mysidekiqworker`. Now, worker names will be displayed as `my_sidekiq_worker`.

Additionally, this PR makes a minor correction to the README and updates 2 DogStatsD metric names to reflect the actual implementation.