### PR TITLE
add yield before enqueue stat

### DIFF
--- a/lib/sidekiq/instrument/middleware/client.rb
+++ b/lib/sidekiq/instrument/middleware/client.rb
@@ -8,10 +8,13 @@ module Sidekiq::Instrument
       # worker_class is a const in sidekiq >= 6.x
       klass = Object.const_get(worker_class.to_s)
       class_instance = klass.new
+
+      result = yield
+
       Statter.statsd.increment(metric_name(class_instance, 'enqueue'))
       Statter.dogstatsd&.increment('sidekiq.enqueue', worker_dog_options(class_instance))
-      result = yield
       Statter.dogstatsd&.flush(sync: true)
+
       result
     end
   end

--- a/lib/sidekiq/instrument/middleware/client.rb
+++ b/lib/sidekiq/instrument/middleware/client.rb
@@ -10,7 +10,7 @@ module Sidekiq::Instrument
       class_instance = klass.new
 
       result = yield
-
+      
       Statter.statsd.increment(metric_name(class_instance, 'enqueue'))
       Statter.dogstatsd&.increment('sidekiq.enqueue', worker_dog_options(class_instance))
       Statter.dogstatsd&.flush(sync: true)

--- a/spec/sidekiq-instrument/client_middleware_spec.rb
+++ b/spec/sidekiq-instrument/client_middleware_spec.rb
@@ -58,8 +58,7 @@ RSpec.describe Sidekiq::Instrument::ClientMiddleware do
       before do
         Sidekiq.configure_client do |c|
           c.client_middleware do |chain|
-            chain.insert_before described_class, FakeMiddleware
-            # chain.add described_class
+            chain.add FakeMiddleware
           end
         end
       end
@@ -73,19 +72,17 @@ RSpec.describe Sidekiq::Instrument::ClientMiddleware do
       end
 
       class FakeMiddleware
-        # include Sidekiq::ClientMiddleware
         def call(worker_class, job, queue, redis_pool)
           raise 'fake error'
         end
       end
 
       it 'does not increment the enqueue stat' do
-        # expect { MyErroneousWorker.perform_async}.to yield_control
         expect(Sidekiq::Instrument::Statter.dogstatsd).not_to receive(:increment)
-        # expect { MyWorker.perform_async }.to raise_error('fake error')
-        # MyWorker.perform_async
+        expect { MyWorker.perform_async }.to raise_error('fake error')
       end
     end
+
     context 'with fakemiddleware error' do
       it 'does increment the enqueue stat' do
         expect(Sidekiq::Instrument::Statter.dogstatsd).to receive(:increment)

--- a/spec/sidekiq-instrument/client_middleware_spec.rb
+++ b/spec/sidekiq-instrument/client_middleware_spec.rb
@@ -53,5 +53,17 @@ RSpec.describe Sidekiq::Instrument::ClientMiddleware do
         expect { MyWorker.perform_async }.not_to raise_error
       end
     end
+
+    context 'no stat increment before yielding' do
+      before do
+        allow_any_instance_of(MyWorker).to receive(:perform_async).and_yield(true)
+      end
+
+      it 'does not increment the enqueue stat' do
+        MyWorker.perform_async
+        expect(Sidekiq::Instrument::Statter.dogstatsd).not_to receive(:increment).with('sidekiq.enqueue', { tags: ['queue:default', 'worker:my_worker'] })
+      end
+    end
+    end
   end
 end


### PR DESCRIPTION
In the event something happening during the .call when using sidekiq::instrument we want to yield,  thus should not have a mismatched enqueue count.