### PR TITLE
create a private tags method that can be overridden by the app

### DIFF
--- a/lib/sidekiq/instrument/version.rb
+++ b/lib/sidekiq/instrument/version.rb
@@ -1,5 +1,5 @@
 module Sidekiq
   module Instrument
-    VERSION = "0.5.4"
+    VERSION = '0.5.5'
   end
 end


### PR DESCRIPTION
🍏 

Allow individual apps the ability to override DataDog tags


## Usage
Override the `dd_tags` private method to add more tags based on queue name or other characteristics 
```ruby
class MyStatsWorker < Sidekiq::Instrument::Worker
  private
  
  def dd_tags(queue)
    custom_tags = []
    queue_type = queue.name.match?(/readonly$/) ? 'read_only'  : 'regular'
    custom_tags << "queue_type:#{queue_type}"

    super(queue) | custom_tags
  end  
end
```