### PR TITLE
Fix Worker Stat Metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         ruby-version: [2.6, 2.7, 3.0]
-        redis-version: [7]
+        redis-version: [4, 5, 6, 7]
 
     steps:
       - name: Checkout project

--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ Sidekiq.configure_client do |config|
     chain.add Sidekiq::Instrument::ClientMiddleware
   end
 end
+
+Sidekiq::Instrument::WorkerMetrics.enabled = true # Set true to enable worker metrics
+Sidekiq::Instrument::WorkerMetrics.namespace = <APP_NAME>
 ```
 
 ## StatsD Keys
@@ -78,7 +81,7 @@ For each job, the following metrics will be reported:
    worker begins performing a job.
 3. **shared.sidekiq._queue_._job_.runtime**: timer of the total time spent
    in `perform`, in milliseconds.
-3. **shared.sidekiq._queue_._job_.error**: counter incremented each time a
+4. **shared.sidekiq._queue_._job_.error**: counter incremented each time a
    job fails.
 
 The metric names can be changed by overriding the `statsd_metric_name`
@@ -86,7 +89,10 @@ method in your worker classes.
 
 For each queue, the following metrics will be reported:
 1. **shared.sidekiq._queue_.size**: gauge of how many jobs are in the queue
-1. **shared.sidekiq._queue_.latency**: gauge of how long the oldest job has been in the queue
+2. **shared.sidekiq._queue_.latency**: gauge of how long the oldest job has been in the queue
+
+For each worker, the following metrics and tags will be reported:
+1. **sidekiq.worker_metrics.inqueue.#{key}**: number of jobs "in queue" per worker, uses redis to track increment/decrement
 
 ## DogStatsD Keys
 For each job, the following metrics and tags will be reported:
@@ -97,12 +103,15 @@ For each job, the following metrics and tags will be reported:
    worker begins performing a job.
 3. **sidekiq.runtime (tags: {queue: _queue_, worker: _job_})**: timer of the total time spent
    in `perform`, in milliseconds.
-3. **sidekiq.error (tags: {queue: _queue_, worker: _job_})**: counter incremented each time a
+4. **sidekiq.error (tags: {queue: _queue_, worker: _job_})**: counter incremented each time a
    job fails.
 
 For each queue, the following metrics and tags will be reported:
 1. **sidekiq.queue.size (tags: {queue: _queue_})**: gauge of how many jobs are in the queue
-1. **sidekiq.queue.latency (tags: {queue: _queue_})**: gauge of how long the oldest job has been in the queue
+2. **sidekiq.queue.latency (tags: {queue: _queue_})**: gauge of how long the oldest job has been in the queue
+
+For each worker, the following metrics and tags will be reported:
+1. **sidekiq.worker_metrics.inqueue.#{key}**: number of jobs "in queue" per worker, uses redis to track increment/decrement
 
 ## Worker
 There is a worker, `Sidekiq::Instrument::Worker`, that submits gauges

--- a/lib/sidekiq/instrument/version.rb
+++ b/lib/sidekiq/instrument/version.rb
@@ -1,5 +1,5 @@
 module Sidekiq
   module Instrument
-    VERSION = '0.5.6'
+    VERSION = '0.6.0'
   end
 end

--- a/lib/sidekiq/instrument/worker.rb
+++ b/lib/sidekiq/instrument/worker.rb
@@ -64,8 +64,8 @@ module Sidekiq::Instrument
       return unless WorkerMetrics.enabled
 
       WorkerMetrics.workers_in_queue.each do |key, value|
-        Statter.statsd.gauge("shared.sidekiq.trace.inqueue.#{key}", value)
-        Statter.dogstatsd&.gauge("shared.sidekiq.trace.inqueue.#{key}", value)
+        Statter.statsd.gauge("shared.sidekiq.worker_metrics.inqueue.#{key}", value)
+        Statter.dogstatsd&.gauge("shared.sidekiq.worker_metrics.inqueue.#{key}", value)
       end
     end
   end

--- a/sidekiq-instrument.gemspec
+++ b/sidekiq-instrument.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'statsd-instrument', '>= 2.0.4'
   spec.add_dependency 'dogstatsd-ruby', '~> 5.5'
   spec.add_dependency 'activesupport', '>= 5.1', '< 7'
-  spec.add_dependency "redis-client", ">= 0.11.0"
+  spec.add_dependency "redis-client", ">= 0.14.1"
 
   spec.add_development_dependency 'bundler', '~> 2.0', '>= 2.0.2'
   spec.add_development_dependency 'rake', '~> 12.0'

--- a/spec/sidekiq-instrument/client_middleware_spec.rb
+++ b/spec/sidekiq-instrument/client_middleware_spec.rb
@@ -46,11 +46,6 @@ RSpec.describe Sidekiq::Instrument::ClientMiddleware do
       it 'increments the enqueue counter' do
           Sidekiq::Instrument::WorkerMetrics.enabled = true
           Redis.new.hdel worker_metric_name ,'my_other_worker'
-          Sidekiq::Instrument::WorkerMetrics.redis_config = {
-            host:        ENV['REDIS_HOST'],
-            port:        ENV['REDIS_PORT'],
-            db:          0
-          }
           MyOtherWorker.perform_async
           expect(
           Redis.new.hget worker_metric_name ,'my_other_worker'

--- a/spec/sidekiq-instrument/server_middleware_spec.rb
+++ b/spec/sidekiq-instrument/server_middleware_spec.rb
@@ -45,11 +45,6 @@ RSpec.describe Sidekiq::Instrument::ServerMiddleware do
         end
         it 'increments the enqueue counter' do
             Sidekiq::Instrument::WorkerMetrics.enabled = true
-            Sidekiq::Instrument::WorkerMetrics.redis_config = {
-              host:        ENV['REDIS_HOST'],
-              port:        ENV['REDIS_PORT'],
-              db:          0
-            }
             Redis.new.hdel worker_metric_name ,'my_other_worker'
             MyOtherWorker.perform_async
             expect(

--- a/spec/sidekiq-instrument/worker_spec.rb
+++ b/spec/sidekiq-instrument/worker_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Sidekiq::Instrument::Worker do
       end
 
       it_behaves_like 'worker behavior', %w[
-        shared.sidekiq.trace.inqueue.my_other_worker
+        shared.sidekiq.worker_metrics.inqueue.my_other_worker
         sidekiq.processed
         sidekiq.workers
         sidekiq.pending


### PR DESCRIPTION
The previous implementation https://github.com/enova/sidekiq-instrument/pull/21 does not work with redis versions below 6. In order to make this backwards & forwards compatible:

- removed redis config. Sidekiq Instrument assumes Sidekiq is running. Thus `Sidekiq.redis` is used. I also don't ever really see a reason, in the future, how an external redis would be used. I am removing it
- Does not incorporate a pool user from redis config. uses sidekiq instead
- adds CI redis version: 4, 5, 6, 7 to ensure it is backwards/forwards compatible