### PR TITLE
add tags to worker metrics

### DIFF
--- a/lib/sidekiq/instrument/version.rb
+++ b/lib/sidekiq/instrument/version.rb
@@ -1,5 +1,5 @@
 module Sidekiq
   module Instrument
-    VERSION = '0.6.0'
+    VERSION = '0.6.1'
   end
 end

--- a/lib/sidekiq/instrument/worker.rb
+++ b/lib/sidekiq/instrument/worker.rb
@@ -65,7 +65,7 @@ module Sidekiq::Instrument
 
       WorkerMetrics.workers_in_queue.each do |key, value|
         Statter.statsd.gauge("shared.sidekiq.worker_metrics.inqueue.#{key}", value)
-        Statter.dogstatsd&.gauge("shared.sidekiq.worker_metrics.inqueue.#{key}", value)
+        Statter.dogstatsd&.gauge("shared.sidekiq.worker_metrics.inqueue", value, tags: ["worker:#{key}"])
       end
     end
   end

--- a/spec/sidekiq-instrument/worker_spec.rb
+++ b/spec/sidekiq-instrument/worker_spec.rb
@@ -33,7 +33,11 @@ RSpec.describe Sidekiq::Instrument::Worker do
           allow(dogstatsd).to receive(:gauge).with('sidekiq.queue.size', any_args).at_least(:once)
           allow(dogstatsd).to receive(:gauge).with('sidekiq.queue.latency', any_args).at_least(:once)
           expected_stats.each do |ex|
-            expect(dogstatsd).to receive(:gauge).with(ex, anything)
+            if ex.include?('shared.sidekiq.worker_metrics.inqueue')
+              expect(dogstatsd).to receive(:gauge).with(ex, anything, anything)
+            else
+              expect(dogstatsd).to receive(:gauge).with(ex, anything)
+            end
           end
           worker.perform
         end
@@ -104,7 +108,7 @@ RSpec.describe Sidekiq::Instrument::Worker do
       end
 
       it_behaves_like 'worker behavior', %w[
-        shared.sidekiq.worker_metrics.inqueue.my_other_worker
+        shared.sidekiq.worker_metrics.inqueue
         sidekiq.processed
         sidekiq.workers
         sidekiq.pending


### PR DESCRIPTION
Adds tagging to dogstatsd worker metric so that we can easily group by worker.