### PR TITLE
Add Datadog tracing to client, server, & worker instrumentation code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/lib/sidekiq/instrument/middleware/client.rb
+++ b/lib/sidekiq/instrument/middleware/client.rb
@@ -2,20 +2,28 @@
 
 require 'sidekiq/instrument/mixin'
 require 'active_support/core_ext/string/inflections'
+require 'ddtrace'
 
 module Sidekiq::Instrument
   class ClientMiddleware
     include Sidekiq::Instrument::MetricNames
 
-    def call(worker_class, job, queue, redis_pool)
-      # worker_class is a const in sidekiq >= 6.x
-      klass = Object.const_get(worker_class.to_s)
-      class_instance = klass.new
-      Statter.statsd.increment(metric_name(class_instance, 'enqueue'))
-      Statter.dogstatsd&.increment('sidekiq.enqueue', worker_dog_options(class_instance))
-      WorkerMetrics.trace_workers_increment_counter(klass.name.underscore, redis_pool)
-      result = yield
-      Statter.dogstatsd&.flush(sync: true)
+    def call(worker_class, job, _queue, redis_pool)
+      span = Datadog::Tracing.trace('sidekiq.job.enqueue', service: 'sidekiq', resource: job['class'])
+      begin
+        # worker_class is a const in sidekiq >= 6.x
+        klass = Object.const_get(worker_class.to_s)
+        class_instance = klass.new
+        Statter.statsd.increment(metric_name(class_instance, 'enqueue'))
+        Statter.dogstatsd&.increment('sidekiq.enqueue', worker_dog_options(class_instance))
+        WorkerMetrics.trace_workers_increment_counter(klass.name.underscore, redis_pool)
+        result = yield
+      rescue StandardError => e
+        span.set_error(e)
+      ensure
+        span.finish
+        Statter.dogstatsd&.flush(sync: true)
+      end
       result
     end
   end

--- a/lib/sidekiq/instrument/middleware/client.rb
+++ b/lib/sidekiq/instrument/middleware/client.rb
@@ -9,7 +9,7 @@ module Sidekiq::Instrument
     include Sidekiq::Instrument::MetricNames
 
     def call(worker_class, job, _queue, redis_pool)
-      span = Datadog::Tracing.trace('sidekiq.job.enqueue', resource: job['class'])
+      span = Datadog::Tracing.trace('sidekiq.job.enqueue', service: Datadog.configuration[:service], resource: job['class'])
       begin
         # worker_class is a const in sidekiq >= 6.x
         klass = Object.const_get(worker_class.to_s)

--- a/lib/sidekiq/instrument/middleware/client.rb
+++ b/lib/sidekiq/instrument/middleware/client.rb
@@ -9,7 +9,7 @@ module Sidekiq::Instrument
     include Sidekiq::Instrument::MetricNames
 
     def call(worker_class, job, _queue, redis_pool)
-      span = Datadog::Tracing.trace('sidekiq.job.enqueue', service: 'sidekiq', resource: job['class'])
+      span = Datadog::Tracing.trace('sidekiq.job.enqueue', resource: job['class'])
       begin
         # worker_class is a const in sidekiq >= 6.x
         klass = Object.const_get(worker_class.to_s)

--- a/lib/sidekiq/instrument/middleware/server.rb
+++ b/lib/sidekiq/instrument/middleware/server.rb
@@ -9,7 +9,7 @@ module Sidekiq::Instrument
     include Sidekiq::Instrument::MetricNames
 
     def call(worker, job, _queue, &block)
-      span = Datadog::Tracing.trace('sidekiq.job.dequeue', service: 'sidekiq', resource: job['class'])
+      span = Datadog::Tracing.trace('sidekiq.job.dequeue', resource: job['class'])
       begin
         Statter.statsd.increment(metric_name(worker, 'dequeue'))
         Statter.dogstatsd&.increment('sidekiq.dequeue', worker_dog_options(worker))

--- a/lib/sidekiq/instrument/middleware/server.rb
+++ b/lib/sidekiq/instrument/middleware/server.rb
@@ -2,27 +2,33 @@
 
 require 'sidekiq/instrument/mixin'
 require 'active_support/core_ext/string/inflections'
+require 'ddtrace'
 
 module Sidekiq::Instrument
   class ServerMiddleware
     include Sidekiq::Instrument::MetricNames
 
-    def call(worker, _job, _queue, &block)
-      Statter.statsd.increment(metric_name(worker, 'dequeue'))
-      Statter.dogstatsd&.increment('sidekiq.dequeue', worker_dog_options(worker))
+    def call(worker, job, _queue, &block)
+      span = Datadog::Tracing.trace('sidekiq.job.dequeue', service: 'sidekiq', resource: job['class'])
+      begin
+        Statter.statsd.increment(metric_name(worker, 'dequeue'))
+        Statter.dogstatsd&.increment('sidekiq.dequeue', worker_dog_options(worker))
 
-      start_time = Time.now
-      yield block
-      execution_time_ms = (Time.now - start_time) * 1000
-      Statter.statsd.measure(metric_name(worker, 'runtime'), execution_time_ms)
-      Statter.dogstatsd&.timing('sidekiq.runtime', execution_time_ms, worker_dog_options(worker))
-    rescue StandardError => e
-      Statter.statsd.increment(metric_name(worker, 'error'))
-      Statter.dogstatsd&.increment('sidekiq.error', worker_dog_options(worker))
-      raise e
-    ensure
-      WorkerMetrics.trace_workers_decrement_counter(worker.class.to_s.underscore)
-      Statter.dogstatsd&.flush(sync: true)
+        start_time = Time.now
+        yield block
+        execution_time_ms = (Time.now - start_time) * 1000
+        Statter.statsd.measure(metric_name(worker, 'runtime'), execution_time_ms)
+        Statter.dogstatsd&.timing('sidekiq.runtime', execution_time_ms, worker_dog_options(worker))
+      rescue StandardError => e
+        span.set_error(e)
+        Statter.statsd.increment(metric_name(worker, 'error'))
+        Statter.dogstatsd&.increment('sidekiq.error', worker_dog_options(worker))
+        raise e
+      ensure
+        span.finish
+        WorkerMetrics.trace_workers_decrement_counter(worker.class.to_s.underscore)
+        Statter.dogstatsd&.flush(sync: true)
+      end
     end
   end
 end

--- a/lib/sidekiq/instrument/middleware/server.rb
+++ b/lib/sidekiq/instrument/middleware/server.rb
@@ -9,7 +9,7 @@ module Sidekiq::Instrument
     include Sidekiq::Instrument::MetricNames
 
     def call(worker, job, _queue, &block)
-      span = Datadog::Tracing.trace('sidekiq.job.dequeue', resource: job['class'])
+      span = Datadog::Tracing.trace('sidekiq.job.dequeue', service: Datadog.configuration[:service], resource: job['class'])
       begin
         Statter.statsd.increment(metric_name(worker, 'dequeue'))
         Statter.dogstatsd&.increment('sidekiq.dequeue', worker_dog_options(worker))

--- a/lib/sidekiq/instrument/version.rb
+++ b/lib/sidekiq/instrument/version.rb
@@ -1,5 +1,5 @@
 module Sidekiq
   module Instrument
-    VERSION = '0.6.2'
+    VERSION = '0.7.0'
   end
 end

--- a/lib/sidekiq/instrument/worker.rb
+++ b/lib/sidekiq/instrument/worker.rb
@@ -19,7 +19,7 @@ module Sidekiq::Instrument
     }.freeze
 
     def perform
-      span = Datadog::Tracing.trace('sidekiq.job.perform', service: 'sidekiq', resource: self.class.to_s)
+      span = Datadog::Tracing.trace('sidekiq.job.perform', resource: self.class.to_s)
       begin
         info = Sidekiq::Stats.new
 

--- a/lib/sidekiq/instrument/worker.rb
+++ b/lib/sidekiq/instrument/worker.rb
@@ -19,7 +19,7 @@ module Sidekiq::Instrument
     }.freeze
 
     def perform
-      span = Datadog::Tracing.trace('sidekiq.job.perform', resource: self.class.to_s)
+      span = Datadog::Tracing.trace('sidekiq.job.perform', service: Datadog.configuration[:service], resource: self.class.to_s)
       begin
         info = Sidekiq::Stats.new
 

--- a/sidekiq-instrument.gemspec
+++ b/sidekiq-instrument.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'sidekiq', '>= 4.2', '< 7'
   spec.add_dependency 'statsd-instrument', '>= 2.0.4'
+  spec.add_dependency 'ddtrace', '~> 1.0'
   spec.add_dependency 'dogstatsd-ruby', '~> 5.5'
   spec.add_dependency 'activesupport', '>= 5.1', '< 7'
   spec.add_dependency "redis-client", ">= 0.14.1"


### PR DESCRIPTION
This PR adds support for Datadog error tracing to the sidekiq-instrument library. Doing so should enable adopters to rely upon Datadog's Error tracing functionality rather than emitting logs and stack traces for every encountered error (which can balloon log ingestion costs).