### PR TITLE
rescue all exceptions for metrics

### DIFF
--- a/lib/sidekiq/instrument/middleware/server.rb
+++ b/lib/sidekiq/instrument/middleware/server.rb
@@ -15,8 +15,8 @@ module Sidekiq::Instrument
       start_time = Time.now
       yield block
       execution_time_ms = (Time.now - start_time) * 1000
-      Statter.statsd.measure(metric_name(worker, 'runtime'), execution_time_ms)
       Statter.dogstatsd&.timing('sidekiq.runtime', execution_time_ms, worker_dog_options(worker))
+      Statter.statsd.measure(metric_name(worker, 'runtime'), execution_time_ms)
     rescue Exception => e
       dd_options = worker_dog_options(worker)
       dd_options[:tags] << "error:#{e.class.name}"

--- a/lib/sidekiq/instrument/middleware/server.rb
+++ b/lib/sidekiq/instrument/middleware/server.rb
@@ -17,15 +17,21 @@ module Sidekiq::Instrument
       execution_time_ms = (Time.now - start_time) * 1000
       Statter.statsd.measure(metric_name(worker, 'runtime'), execution_time_ms)
       Statter.dogstatsd&.timing('sidekiq.runtime', execution_time_ms, worker_dog_options(worker))
-    rescue StandardError => e
+    rescue Exception => e
+      dd_options = worker_dog_options(worker)
+      dd_options[:tags] << "error:#{e.class.name}"
+
       # if we have retries left, increment the enqueue.retry counter to indicate the job is going back on the queue
       if max_retries(worker) > current_retries(job) + 1
         WorkerMetrics.trace_workers_increment_counter(worker.class.to_s.underscore)
-        Statter.dogstatsd&.increment('sidekiq.enqueue.retry', worker_dog_options(worker))
+        Statter.dogstatsd&.increment('sidekiq.enqueue.retry', dd_options)
       end
 
+      # categorize rate limit lock errors differently from actual errors
+      error_string = e.class.name.eql?("RedisRateLimit::Throttle::LockFailedError") ? 'sidekiq.error.redis_rate_lock' : 'sidekiq.error'
+      Statter.dogstatsd&.increment(error_string, dd_options)
       Statter.statsd.increment(metric_name(worker, 'error'))
-      Statter.dogstatsd&.increment('sidekiq.error', worker_dog_options(worker))
+
       raise e
     ensure
       WorkerMetrics.trace_workers_decrement_counter(worker.class.to_s.underscore)

--- a/lib/sidekiq/instrument/middleware/server.rb
+++ b/lib/sidekiq/instrument/middleware/server.rb
@@ -27,9 +27,7 @@ module Sidekiq::Instrument
         Statter.dogstatsd&.increment('sidekiq.enqueue.retry', dd_options)
       end
 
-      # categorize rate limit lock errors differently from actual errors
-      error_string = e.class.name.eql?("RedisRateLimit::Throttle::LockFailedError") ? 'sidekiq.error.redis_rate_lock' : 'sidekiq.error'
-      Statter.dogstatsd&.increment(error_string, dd_options)
+      Statter.dogstatsd&.increment('sidekiq.error', dd_options)
       Statter.statsd.increment(metric_name(worker, 'error'))
 
       raise e

--- a/lib/sidekiq/instrument/version.rb
+++ b/lib/sidekiq/instrument/version.rb
@@ -1,5 +1,5 @@
 module Sidekiq
   module Instrument
-    VERSION = '0.7.1'
+    VERSION = '0.7.2'
   end
 end


### PR DESCRIPTION
Currently because the `rescue` only captures `StandardError` type errors, we're not getting into the rescue block for all of the issues Sidekiq workers are experiencing.

This PR:

- Changes `rescue StandardError => e` to now be `rescue Exception => e` to properly handle gathering stats for all potential error types. The error is re-raised at the end of the rescue so there is no need for concern in widening the umbrella of what we're catching.
- Adds an `error` tag to the DataDog stats reported so we can get granular data on what error types our worker's are experiencing