### PR TITLE
add optional tags to datadog metrics

### DIFF
--- a/lib/sidekiq/instrument/middleware/client.rb
+++ b/lib/sidekiq/instrument/middleware/client.rb
@@ -20,7 +20,7 @@ module Sidekiq::Instrument
       if Sidekiq::Context.current[:class].present?
         WorkerMetrics.trace_workers_increment_counter(klass.name.underscore)
         Statter.statsd.increment(metric_name(class_instance, 'enqueue'))
-        Statter.dogstatsd&.increment('sidekiq.enqueue', worker_dog_options(class_instance))
+        Statter.dogstatsd&.increment('sidekiq.enqueue', worker_dog_options(class_instance, job))
       end
 
       Statter.dogstatsd&.flush(sync: true)

--- a/lib/sidekiq/instrument/mixin.rb
+++ b/lib/sidekiq/instrument/mixin.rb
@@ -9,12 +9,11 @@ module Sidekiq::Instrument
     end
 
     def worker_dog_options(worker, job)
-      tags = job.dig('tags') || []
       {
         tags: [
           "queue:#{queue_name(worker)}",
           "worker:#{underscore(class_name(worker))}"
-        ].concat(tags)
+        ].concat(job.fetch('tags', []))
       }
     end
 

--- a/lib/sidekiq/instrument/mixin.rb
+++ b/lib/sidekiq/instrument/mixin.rb
@@ -8,8 +8,14 @@ module Sidekiq::Instrument
       end
     end
 
-    def worker_dog_options(worker)
-      { tags: ["queue:#{queue_name(worker)}", "worker:#{underscore(class_name(worker))}"] }
+    def worker_dog_options(worker, job)
+      tags = job.dig('tags') || []
+      {
+        tags: [
+          "queue:#{queue_name(worker)}",
+          "worker:#{underscore(class_name(worker))}"
+        ].concat(tags)
+      }
     end
 
     def max_retries(worker)

--- a/lib/sidekiq/instrument/version.rb
+++ b/lib/sidekiq/instrument/version.rb
@@ -1,5 +1,5 @@
 module Sidekiq
   module Instrument
-    VERSION = '0.7.2'
+    VERSION = '0.7.3'
   end
 end

--- a/spec/sidekiq-instrument/client_middleware_spec.rb
+++ b/spec/sidekiq-instrument/client_middleware_spec.rb
@@ -46,6 +46,17 @@ RSpec.describe Sidekiq::Instrument::ClientMiddleware do
           ).to receive(:increment).with('sidekiq.enqueue', { tags: ['queue:default', 'worker:my_worker'] }).once
           MyWorker.perform_async
         end
+
+        context 'with additional tag(s)' do
+          it 'increments DogStatsD enqueue counter with additional tag(s)' do
+            tag = 'test_worker'
+
+            expect(
+              Sidekiq::Instrument::Statter.dogstatsd
+            ).to receive(:increment).with('sidekiq.enqueue', { tags: ['queue:default', 'worker:my_worker', tag] }).once
+            MyWorker.set(tags: [tag]).perform_async
+          end
+        end
       end
 
       context 'with statsd_metric_name' do


### PR DESCRIPTION
Adds any optional tags set in [sidekiq_options](https://github.com/sidekiq/sidekiq/wiki/Advanced-Options#jobs) to the DataDog metric emissions.