### PR TITLE
Track scheduled vs enqueued metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,16 +75,18 @@ Sidekiq::Instrument::WorkerMetrics.namespace = <APP_NAME>
 ## StatsD Keys
 For each job, the following metrics will be reported:
 
-1. **shared.sidekiq._queue_._job_.enqueue**: counter incremented each time a
+1. **shared.sidekiq._queue_._job_.schedule**: counter incremented each time a
+   job is scheduled to be pushed onto the queue later.
+2. **shared.sidekiq._queue_._job_.enqueue**: counter incremented each time a
    job is pushed onto the queue.
-2. **shared.sidekiq._queue_._job_.dequeue**: counter incremented just before
+3. **shared.sidekiq._queue_._job_.dequeue**: counter incremented just before
    worker begins performing a job.
-3. **shared.sidekiq._queue_._job_.runtime**: timer of the total time spent
+4. **shared.sidekiq._queue_._job_.runtime**: timer of the total time spent
    in `perform`, in milliseconds.
-4. **shared.sidekiq._queue_._job_.error**: counter incremented each time a
+5. **shared.sidekiq._queue_._job_.error**: counter incremented each time a
    job fails.
 
-For job retry attempts, the above 4 metrics will still be reported but the enqueue/dequeue metrics
+For job retry attempts, metrics 2-5 will still be reported but the enqueue/dequeue metrics
 will have a `.retry` appended:
 
 1. **shared.sidekiq._queue_._job_.enqueue.retry**
@@ -103,13 +105,15 @@ For each worker, the following metrics and tags will be reported:
 ## DogStatsD Keys
 For each job, the following metrics and tags will be reported:
 
-1. **sidekiq.enqueue (tags: {queue: _queue_, worker: _job_})**: counter incremented each time a
+1. **sidekiq.schedule (tags: {queue: _queue_, worker: _job_})**: counter incremented each time a
+   job is scheduled to be pushed onto the queue later.
+2. **sidekiq.enqueue (tags: {queue: _queue_, worker: _job_})**: counter incremented each time a
    job is pushed onto the queue.
-2. **sidekiq.dequeue (tags: {queue: _queue_, worker: _job_})**: counter incremented just before
+3. **sidekiq.dequeue (tags: {queue: _queue_, worker: _job_})**: counter incremented just before
    worker begins performing a job.
-3. **sidekiq.runtime (tags: {queue: _queue_, worker: _job_})**: timer of the total time spent
+4. **sidekiq.runtime (tags: {queue: _queue_, worker: _job_})**: timer of the total time spent
    in `perform`, in milliseconds.
-4. **sidekiq.error (tags: {queue: _queue_, worker: _job_})**: counter incremented each time a
+5. **sidekiq.error (tags: {queue: _queue_, worker: _job_, error: _errorclass_})**: counter incremented each time a
    job fails.
 
 For job retry attempts, the above 4 metrics will still be reported but the enqueue/dequeue metrics
@@ -127,7 +131,7 @@ For each worker, the following metrics and tags will be reported:
 
 ## Worker
 
-**WARNING: The metrics reported by this Worker are currently inaccurate.**
+**WARNING: The Redis count metrics reported by this Worker are currently inaccurate.**
 
 There is a worker, `Sidekiq::Instrument::Worker`, that submits gauges
 for various interesting statistics; namely, the bulk of the information in `Sidekiq::Stats`

--- a/lib/sidekiq/instrument/version.rb
+++ b/lib/sidekiq/instrument/version.rb
@@ -1,5 +1,5 @@
 module Sidekiq
   module Instrument
-    VERSION = '0.7.3'
+    VERSION = '0.7.4'
   end
 end


### PR DESCRIPTION
Fixes a previously incorrect finding that `Sidekiq::Context.current[:class].present?` would help us differentiate whether or not to categorize a passthrough of a job through the Client middleware as an `enqueue`.

The more appropriate determining factor is actually the presence of the numeric timestamp typed `at` field that is passed within the `job` parameter for scheduled jobs. The presence of `at` indicates that this job is not being placed on a queue right now, but  rather it is being scheduled to be enqueued later at the numeric timestamp value of `at`.

This change will prepare the Client Middleware to correctly handle the following two ways a worker can perform:
- `perform_async`: a job is not scheduled and immediately is enqueued with no `at` field.
- `perform_in`: a job is scheduled and passed in with an `at` field for when it should hit the middleware an additional time without the `at` field to be enqueued.

The other types of performs don't hit the Client Middleware at all, as `perform_inline` and `new.perform` cause a job to execute synchronously.

Example `job` payload when `perform_in(1.second)` is used by a worker:
```
{
       "retry" => true,
       "queue" => "some_queue",
       "backtrace" => 10,
       "lock" => :until_executed,
       "on_conflict" => :log,
       "args" => [1],
       "class" => "SomeWorker",
       "jid" => "fee1b8f9a57141629fa03657",
       "created_at" => 1727312692.754786,
       "lock_timeout" => 0,
       "lock_ttl" => 600,
       "lock_prefix" => "uniquejobs",
       "lock_args" => [1],
       "lock_digest" => "uniquejobs:18644d31fbaec54e24fc2253c0180bff",
       "at" => 1727312693.755
}
```
You can see above that the numeric timestamp value of `at` is the value of `created_at` with an additional second added to the timestamp.