### PR TITLE
Support Rails 7.1.x

### DIFF
--- a/lib/sidekiq/instrument/middleware/client.rb
+++ b/lib/sidekiq/instrument/middleware/client.rb
@@ -20,7 +20,7 @@ module Sidekiq::Instrument
       # perform_in:
       #   - once when it is scheduled, with job['at'] key
       #   - once when it is enqueued, without job['at'] key
-      if job['at'].present?
+      unless job['at'].nil?
         Statter.statsd.increment(metric_name(class_instance, 'schedule'))
         Statter.dogstatsd&.increment('sidekiq.schedule', worker_dog_options(class_instance, job))
       else

--- a/lib/sidekiq/instrument/middleware/client.rb
+++ b/lib/sidekiq/instrument/middleware/client.rb
@@ -2,6 +2,7 @@
 
 require 'sidekiq/instrument/mixin'
 require 'active_support/core_ext/string/inflections'
+require 'active_support/core_ext/object/blank'
 
 module Sidekiq::Instrument
   class ClientMiddleware
@@ -20,7 +21,7 @@ module Sidekiq::Instrument
       # perform_in:
       #   - once when it is scheduled, with job['at'] key
       #   - once when it is enqueued, without job['at'] key
-      unless job['at'].nil?
+      if job['at'].present?
         Statter.statsd.increment(metric_name(class_instance, 'schedule'))
         Statter.dogstatsd&.increment('sidekiq.schedule', worker_dog_options(class_instance, job))
       else

--- a/sidekiq-instrument.gemspec
+++ b/sidekiq-instrument.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'sidekiq', '>= 4.2', '< 7'
   spec.add_dependency 'statsd-instrument', '>= 2.0.4'
   spec.add_dependency 'dogstatsd-ruby', '~> 5.5'
-  spec.add_dependency 'activesupport', '>= 5.1', '< 7'
+  spec.add_dependency 'activesupport', '>= 5.1', '< 7.2'
   spec.add_dependency "redis-client", ">= 0.14.1"
 
   spec.add_development_dependency 'bundler', '~> 2.0', '>= 2.0.2'


### PR DESCRIPTION
**Changes**: 
- Support rails 7.1.x

**Context**: 
`activesupport` does not automatically load [present?](https://github.com/rails/rails/blob/d73ed958dc91d6b8cbb0bef7b4cdcfc013bd876f/activesupport/lib/active_support/core_ext/object/blank.rb#L25-L27) method into `NilClass` any more so we have to load it manually 

**Testing**:
- Rspec
![Screenshot 2025-03-21 at 12 17 15](https://github.com/user-attachments/assets/e66dab5b-9840-42b4-aa22-2a1d2969034a)
- AWS
![Screenshot 2025-03-21 at 12 19 22](https://github.com/user-attachments/assets/406a8e2b-061e-4e43-ba86-b355a44dc12f)
