### PR TITLE
get queue from job, not worker

### DIFF
--- a/lib/sidekiq/instrument/middleware/client.rb
+++ b/lib/sidekiq/instrument/middleware/client.rb
@@ -22,11 +22,11 @@ module Sidekiq::Instrument
       #   - once when it is scheduled, with job['at'] key
       #   - once when it is enqueued, without job['at'] key
       if job['at'].present?
-        Statter.statsd.increment(metric_name(class_instance, 'schedule'))
+        Statter.statsd.increment(metric_name(class_instance, job, 'schedule'))
         Statter.dogstatsd&.increment('sidekiq.schedule', worker_dog_options(class_instance, job))
       else
         WorkerMetrics.trace_workers_increment_counter(klass.name.underscore)
-        Statter.statsd.increment(metric_name(class_instance, 'enqueue'))
+        Statter.statsd.increment(metric_name(class_instance, job, 'enqueue'))
         Statter.dogstatsd&.increment('sidekiq.enqueue', worker_dog_options(class_instance, job))
       end
 

--- a/lib/sidekiq/instrument/middleware/server.rb
+++ b/lib/sidekiq/instrument/middleware/server.rb
@@ -10,15 +10,15 @@ module Sidekiq::Instrument
     def call(worker, job, _queue, &block)
       dequeue_string = is_retry(job) ? 'dequeue.retry' : 'dequeue'
       Statter.dogstatsd&.increment("sidekiq.#{dequeue_string}", worker_dog_options(worker, job))
-      Statter.statsd.increment(metric_name(worker, dequeue_string))
+      Statter.statsd.increment(metric_name(worker, job, dequeue_string))
 
       start_time = Time.now
       yield block
       execution_time_ms = (Time.now - start_time) * 1000
       Statter.dogstatsd&.timing('sidekiq.runtime', execution_time_ms, worker_dog_options(worker, job))
-      Statter.statsd.measure(metric_name(worker, 'runtime'), execution_time_ms)
+      Statter.statsd.measure(metric_name(worker, job, 'runtime'), execution_time_ms)
       Statter.dogstatsd&.increment('sidekiq.success', worker_dog_options(worker, job))
-      Statter.statsd.increment(metric_name(worker, 'success'))
+      Statter.statsd.increment(metric_name(worker, job, 'success'))
     rescue Exception => e
       dd_options = worker_dog_options(worker, job)
       dd_options[:tags] << "error:#{e.class.name}"
@@ -30,7 +30,7 @@ module Sidekiq::Instrument
       end
 
       Statter.dogstatsd&.increment('sidekiq.error', dd_options)
-      Statter.statsd.increment(metric_name(worker, 'error'))
+      Statter.statsd.increment(metric_name(worker, job, 'error'))
 
       raise e
     ensure

--- a/lib/sidekiq/instrument/mixin.rb
+++ b/lib/sidekiq/instrument/mixin.rb
@@ -1,17 +1,17 @@
 module Sidekiq::Instrument
   module MetricNames
-    def metric_name(worker, event)
+    def metric_name(worker, job, event)
       if worker.respond_to?(:statsd_metric_name)
         worker.send(:statsd_metric_name, event)
       else
-        "shared.sidekiq.#{queue_name(worker)}.#{class_name(worker)}.#{event}"
+        "shared.sidekiq.#{queue_name(job)}.#{class_name(worker)}.#{event}"
       end
     end
 
     def worker_dog_options(worker, job)
       {
         tags: [
-          "queue:#{queue_name(worker)}",
+          "queue:#{queue_name(job)}",
           "worker:#{underscore(class_name(worker))}"
         ].concat(job.fetch('tags', []))
       }
@@ -31,8 +31,8 @@ module Sidekiq::Instrument
 
     private
 
-    def queue_name(worker)
-      worker.class.get_sidekiq_options['queue']
+    def queue_name(job)
+      job['queue']
     end
 
     def class_name(worker)

--- a/lib/sidekiq/instrument/version.rb
+++ b/lib/sidekiq/instrument/version.rb
@@ -1,5 +1,5 @@
 module Sidekiq
   module Instrument
-    VERSION = '0.7.7'
+    VERSION = '0.8.0'
   end
 end

--- a/lib/sidekiq/instrument/version.rb
+++ b/lib/sidekiq/instrument/version.rb
@@ -1,5 +1,5 @@
 module Sidekiq
   module Instrument
-    VERSION = '0.7.6'
+    VERSION = '0.7.7'
   end
 end


### PR DESCRIPTION
Currently, the metric string for StatsD and DataDog is using a queue name that is being inferred from the worker class. This is causing an incorrect queue name to be used when a different queue is set to be used for a job at runtime:

```
SomeWorkerClass.set(queue: :different_queue).perform_async(...)
```

This PR updates the logic to grab the queue name from the job itself, rather than assume its using the queue set within the worker class's Sidekiq settings.